### PR TITLE
Don't obfuscate datacash references

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -78,3 +78,22 @@ SAMPLE_SUCCESSFUL_FULFILL_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
     <time>1338297619</time>
 </Response>"""
 
+SAMPLE_DATACASH_REFERENCE_REQUEST = """<?xml version="1.0" ?>
+<Request>
+    <Authentication>
+        <client>99001381</client>
+        <password>samplepassword</password>
+    </Authentication>
+    <Transaction>
+        <HistoricTxn>
+            <reference>1234567890124209</reference>
+            <method>fulfill</method>
+            <authcode>747595</authcode>
+        </HistoricTxn>
+        <TxnDetails>
+            <merchantreference>100001_FULFILL_1_6664</merchantreference>
+            <amount>767.00</amount>
+            <capturemethod>ecomm</capturemethod>
+        </TxnDetails>
+    </Transaction>
+</Request>"""

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -57,3 +57,15 @@ class TransactionModelTests(TestCase, XmlTestingMixin):
                                               request_xml=fixtures.SAMPLE_REQUEST,
                                               response_xml=fixtures.SAMPLE_RESPONSE)
         self.assertXmlElementEquals(txn.request_xml, 'XXXXXXXXXXXX0004', 'Request.Transaction.CardTxn.Card.pan')
+
+    def test_datacash_refrences_are_not_obfuscated(self):
+        txn = OrderTransaction.objects.create(order_number='1000',
+                                              method='auth',
+                                              datacash_reference='3000000088888888',
+                                              merchant_reference='100001_FULFILL_1_6664',
+                                              amount=D('767.00'),
+                                              status=1,
+                                              reason='ACCEPTED',
+                                              request_xml=fixtures.SAMPLE_DATACASH_REFERENCE_REQUEST,
+                                              response_xml=fixtures.SAMPLE_RESPONSE)
+        self.assertXmlElementEquals(txn.request_xml, '1234567890124209', 'Request.Transaction.HistoricTxn.reference')


### PR DESCRIPTION
The regex for obfuscating card numbers is matching other, more useful, information:

![image](https://f.cloud.github.com/assets/80975/749673/a016ead8-e4b2-11e2-8c2c-7f602c5241a6.png)
